### PR TITLE
v0.1.1

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,6 @@
 # node-pg-rev - Revision History
 
-- 2022-07-24: v0.1.1 - Initial release
+- 2022-07-25: v0.1.1 - Initial release
   - Added defaultFetchDate to processBatch and transformRecords (ensures date before running query is available to transform)
 
 - 2022-07-24: v0.1.0 - Initial release

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,6 @@
 # node-pg-rev - Revision History
 
+- 2022-07-24: v0.1.1 - Initial release
+  - Added defaultFetchDate to processBatch and transformRecords (ensures date before running query is available to transform)
+
 - 2022-07-24: v0.1.0 - Initial release

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@msamblanet/node-pg-rev",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Node utility library for the node-pg system",
   "author": "Michael Samblanet <michael@samblanet.com>",
   "license": "Apache-2.0",


### PR DESCRIPTION
- 2022-07-25: v0.1.1 - Initial release
  - Added defaultFetchDate to processBatch and transformRecords (ensures date before running query is available to transform)
